### PR TITLE
fix: remove alsa backend

### DIFF
--- a/com.adilhanney.ricochlime.yaml
+++ b/com.adilhanney.ricochlime.yaml
@@ -34,6 +34,8 @@ modules:
       - ./patches/foss.sh
       - setup-flutter.sh
       - flutter config --no-cli-animations
+      - ./patches/remove_wasm_libs.sh
+      - sed -i '21i set(SOLOUD_BACKEND_ALSA OFF CACHE BOOL "" FORCE)' linux/CMakeLists.txt
       - flutter build linux --no-pub
       - cp -a ${BUNDLE_PATH}/. /app/bin/
       - install -Dm644 flatpak/com.adilhanney.ricochlime.desktop -t /app/share/applications/

--- a/flatpak-flutter.yaml
+++ b/flatpak-flutter.yaml
@@ -31,6 +31,8 @@ modules:
       - ./patches/remove_dev_dependencies.sh
       - ./patches/foss.sh
       - flutter config --no-cli-animations
+      - ./patches/remove_wasm_libs.sh
+      - sed -i '21i set(SOLOUD_BACKEND_ALSA OFF CACHE BOOL "" FORCE)' linux/CMakeLists.txt
       - flutter build linux --no-pub
       - cp -a ${BUNDLE_PATH}/. /app/bin/
       - install -Dm644 flatpak/com.adilhanney.ricochlime.desktop -t /app/share/applications/


### PR DESCRIPTION
The app got stuck on the loading screen with this error:
`Failed to load dynamic library 'libflutter_soloud_plugin.so': /app/bin/lib/libflutter_soloud_plugin.so: undefined symbol: snd_pcm_close #0`

Audio seems to work fine without the alsa backend.